### PR TITLE
Iogi fails with guava 11.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 		<developer>
 			<id>rafaeldff</id>
 			<name>Rafael Ferreira</name>
-                        <url>http://github.com/rafaeldff</url>
+            <url>http://github.com/rafaeldff</url>
 			<roles><role>leader</role></roles>
 			<timezone>-3</timezone>
 		</developer>
@@ -37,17 +37,17 @@
 		<dependency>
 			<groupId>com.thoughtworks.paranamer</groupId>
 			<artifactId>paranamer</artifactId>
-			<version>2.2</version>
+			<version>2.5</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.guava</groupId>
 		    	<artifactId>guava</artifactId>
-		    	<version>r07</version>
+		    	<version>11.0.2</version>
 		</dependency>
 		<dependency>
 			<groupId>net.vidageek</groupId>
 			<artifactId>mirror</artifactId>
-			<version>1.5.1</version>
+			<version>1.6.1</version>
 		</dependency>
 
 		<dependency>

--- a/src/br/com/caelum/iogi/parameters/Parameter.java
+++ b/src/br/com/caelum/iogi/parameters/Parameter.java
@@ -26,7 +26,7 @@ public class Parameter {
 	}
 	
 	private static ImmutableList<String> computeNameComponents(final String name) {
-		return ImmutableList.of(name.split("\\."));
+		return ImmutableList.copyOf(name.split("\\."));
 	}
 
 	public String getName() {


### PR DESCRIPTION
They changed some method signatures and Iogi broke. This patch fixes Iogi to work with newer guava versions.
