### PR TITLE
Fixing Java 5 compilation

### DIFF
--- a/src/br/com/caelum/iogi/EmptyObjectsProvider.java
+++ b/src/br/com/caelum/iogi/EmptyObjectsProvider.java
@@ -34,7 +34,6 @@ public class EmptyObjectsProvider implements DependencyProvider {
       this.emptySuppliers = emptyInstances;
    }
 
-   @Override
    public boolean canProvide(Target<?> target) {
       return target.getClassType().isArray() || selfCanProvide(target) || underlying.canProvide(target);
    }
@@ -44,7 +43,6 @@ public class EmptyObjectsProvider implements DependencyProvider {
       return emptySuppliers.containsKey(targetType);
    }
 
-   @Override
    public Object provide(Target<?> target) {
       if (target.getClassType().isArray()) {
          return emptyArrayFor(target);
@@ -70,7 +68,6 @@ public class EmptyObjectsProvider implements DependencyProvider {
       
       public static Supplier<Object[]> objectArraySupplier() {
          return new Supplier<Object[]>() {
-            @Override
             public Object[] get() {
                return new Object[0];
             }
@@ -87,7 +84,6 @@ public class EmptyObjectsProvider implements DependencyProvider {
     
       public static Supplier<Map<Object,Object>> mapSupplier() {
          return new Supplier<Map<Object,Object>>() {
-            @Override
             public Map<Object, Object> get() {
                return Maps.newHashMap();
             }

--- a/test/br/com/caelum/iogi/EmptyObjectsProviderTest.java
+++ b/test/br/com/caelum/iogi/EmptyObjectsProviderTest.java
@@ -37,7 +37,6 @@ public class EmptyObjectsProviderTest {
    
    private Class<?> classThatMayBeEmpty = MayBeEmpty.class;
    private Supplier<MayBeEmpty> emptyValueSupplier = new Supplier<MayBeEmpty>() {
-      @Override
       public MayBeEmpty get() {
          return new MayBeEmpty();
       }
@@ -123,12 +122,10 @@ public class EmptyObjectsProviderTest {
                new StringConverter(),
                new ObjectInstantiator(new RecursiveInstantiator(), provider, new ParanamerParameterNamesProvider())));
    private final class RecursiveInstantiator implements Instantiator<Object> {
-      @Override
       public boolean isAbleToInstantiate(Target<?> target) {
          return instantiator.isAbleToInstantiate(target);
       }
 
-      @Override
       public Object instantiate(Target<?> target, Parameters parameters) {
          return instantiator.instantiate(target, parameters);
       }


### PR DESCRIPTION
In the pom.xml project was declared as Java 5 compliance. So `@Override` only works for abstract methods, not for interface methods.

This pull request removes `@Override`. Or if you prefer we can change Java compiler to Java 6 in the pom.
