### PR TITLE
Applying copyright owner in license file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@ Apache License
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright {yyyy} {name of copyright owner}
+   Copyright 2009 Rafael de F. Ferreira
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
As described in APL license guide, the text `Copyright [yyyy] [name of copyright owner]` needs to be replaced with copyright owner and the date of 1st release under this license.
